### PR TITLE
Enforce UTF-8 encoding in the data passed to the match functions.

### DIFF
--- a/beetsplug/originquery.py
+++ b/beetsplug/originquery.py
@@ -179,7 +179,7 @@ class OriginQuery(BeetsPlugin):
 
 
     def match_text(self, origin_path):
-        with open(origin_path) as f:
+        with open(origin_path, encoding="utf-8") as f:
             lines = f.readlines()
 
         for key, pattern in self.tag_patterns.items():
@@ -192,7 +192,7 @@ class OriginQuery(BeetsPlugin):
 
 
     def match_json(self, origin_path):
-        with open(origin_path) as f:
+        with open(origin_path, encoding="utf-8") as f:
             data = json.load(f)
 
         for key, pattern in self.tag_patterns.items():
@@ -204,7 +204,7 @@ class OriginQuery(BeetsPlugin):
 
 
     def match_yaml(self, origin_path):
-        with open(origin_path) as f:
+        with open(origin_path, encoding="utf-8") as f:
             data = yaml.load(f, Loader=yaml.SafeLoader)
 
         for key, pattern in self.tag_patterns.items():


### PR DESCRIPTION
Match_text, match_json, and match_yaml all now enforce UTF-8 coding on their data. This has eliminated unicode errors on my system.

Closes #1.