### PR TITLE
Alter which tags are added to files

### DIFF
--- a/beetsplug/originquery.py
+++ b/beetsplug/originquery.py
@@ -260,7 +260,7 @@ class OriginQuery(BeetsPlugin):
             for item in task.items:
                 for tag, entry in tag_compare.items():
                     origin_value = entry['origin']
-                    if tag not in self.extra_tags:
+                    if tag not in self.tag_patterns.keys():
                         continue
                     if tag == 'year' and origin_value:
                         origin_value = int(origin_value) if origin_value.isdigit() else ''

--- a/beetsplug/originquery.py
+++ b/beetsplug/originquery.py
@@ -233,8 +233,13 @@ class OriginQuery(BeetsPlugin):
         likelies, consensus = current_metadata(task.items)
         task_info['tag_compare'] = tag_compare = OrderedDict()
         for tag in BEETS_TO_LABEL:
+            if tag in likelies.keys():
+                tag_from_mb = str(likelies[tag])
+            else:
+                tag_from_mb = ''
+
             tag_compare.update({tag: {
-                'tagged': str(likelies[tag]),
+                'tagged': tag_from_mb,
                 'active': tag in self.extra_tags,
                 'origin': '',
             }})

--- a/beetsplug/originquery.py
+++ b/beetsplug/originquery.py
@@ -19,6 +19,7 @@ BEETS_TO_LABEL = OrderedDict([
     ('label', 'Record label'),
     ('catalognum', 'Catalog number'),
     ('albumdisambig', 'Edition'),
+    ('original_year', 'Original year'),
 ])
 
 # Conflicts will be reported if any of these fields don't match.


### PR DESCRIPTION
Hi! Thanks for all the work on this project and with `gazelle-origin`. These projects are looking to be a lifesaver for my music collection.

I've opened this PR because this change solves an issue I've been facing with `albumdisambig`. Further, I believe the new behavior is closer to the desired behavior. Basically, I'd like for the `originquery` plugin to add the `albumdisambig` tag to the files when it's listed in `originquery.tag_patterns`. Currently, `originquery` will only add that tag when it's included in the `musicbrainz.extra_tags` config block. If `albumdisambig` is added to that block, there can be unintended downstream effects on the `musicbrainz` plugin (and generally it's not desired that `originquery` configuration is "hidden" in `musicbrainz` configuration). For example, the import breaks if `origin.yaml` doesn't have the `"Edition"`:

```
beets-beets-1  |   File "/usr/local/lib/python3.8/site-packages/beets/autotag/mb.py", line 498, in match_album
beets-beets-1  |     key = FIELDS_TO_MB_KEYS[tag]
beets-beets-1  | KeyError: 'albumdisambig'
```

To illustrate, here is my case study of the current behavior:

----------------------------

I'm attempting to import two versions of Adele's 30. The `origin.yaml` files provide the correct "Edition" field across both releases. For the original, `"Edition"` is blank. For Target exclusive, `origin.yaml` contains `"Edition": Target Exclusive`. So far so good. However, if I run a `beet import` with this config:

```yaml
musicbrainz:
  extra_tags:
    - year
    - catalognum,
    - country,
    - label,
    - media
    
originquery:
  use_origin_on_conflict: yes
  origin_file: origin.yaml
  tag_patterns:
    media: '$.Media'
    year: '$."Edition year"'
    label: '$."Record label"'
    catalognum: '$."Catalog number"'
    albumdisambig: '$.Edition'
```

Beets doesn't add the `albumdisambig` tag during autotagging. It's skipped over because `albumdisambig` isn't in `musicbrainz.extra_tags`. As such, the albums are missing the `albumdisambig` entirely and the files end up in the filesystem like:

```
30 (<backup_disambiguator>)
30 (<backup_disambiguator>)
```

But what I want is:

```
30 (<backup_disambiguator>)
30 (Target Exclusive)
```

-------------------------------------------------

I'd like the `"Edition"` field to populate those parentheses (through `albumdisambig`). The change in this PR fixes this issue by attempting to tag the files if it's in the `originquery.tag_patterns` config block. This also opens up the possibility for additional tags based on `origin.yaml`, if that's desired.

I've testing this change against a few dozen albums and everything works as I'd expect.