### PR TITLE
Lower media weight if catalognum exists

### DIFF
--- a/beetsplug/originquery.py
+++ b/beetsplug/originquery.py
@@ -268,8 +268,7 @@ class OriginQuery(BeetsPlugin):
 
                 # beets weighs media heavily, and will even prioritize a media match over an exact catalognum match.
                 # At the same time, media for uploaded music is often mislabeled (e.g., Enhanced CD and SACD are just
-                # grouped as CD). This does not make a good combination. As a workaround, remove the media from the
-                # item if we also have a catalognum.
+                # grouped as CD). This does not make a good combination. As a workaround, lower the weight for media
+                # if we also have a catalognum.
                 if item['media'] and item['catalognum']:
-                    del item['media']
-                    tag_compare['media']['active'] = False
+                    config['match']['distance_weights']['media'] = .2


### PR DESCRIPTION
Beets doesn't seem to penalized the match distance if a release is missing a catalog number (as far as I can tell but I could easily be wrong).

If, for example, a release has a CD and digital version, and the digital one is missing the catalog number, then if media is removed from the query because the origin file has a catalog number, both media and catalog number might end up being ignored.